### PR TITLE
Fix typo in personal description

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -17,7 +17,7 @@ export default () => (
         <h1 className="panel__header">Christopher Wheatley</h1>
         <div className="panel__body">
           Software Developer with a degree in computer science and 4 years commercial experience
-          using web technologies. Conscientious, comitted and friendly.
+          using web technologies. Conscientious, committed and friendly.
           <div className="panel__actions">
             <ProtectedEmailLink base64Email="Y2hyaXNAY2hyaXN0b3BoZXJ3aGVhdGxleS51aw==" />
             <a


### PR DESCRIPTION
Correct a typo in the spelling of 'committed' in the personal description of the main page.