### PR TITLE
feat(seo): Improve seo with a sitemap.

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,13 +1,16 @@
+const SITE_URL = 'https://www.christopherwheatley.uk';
+
 module.exports = {
   siteMetadata: {
     title: 'Christopher Wheatley',
     subtitle: 'Software Developer',
+    siteUrl: SITE_URL,
   },
   plugins: [
     {
       resolve: 'gatsby-plugin-canonical-urls',
       options: {
-        siteUrl: 'https://www.christopherwheatley.uk',
+        siteUrl: SITE_URL,
       },
     },
     {
@@ -20,6 +23,12 @@ module.exports = {
         theme_color: '#5652c5',
         icon: 'src/images/icon.png',
         include_favicon: true,
+      },
+    },
+    {
+      resolve: 'gatsby-plugin-sitemap',
+      options: {
+        sitemapSize: 5000,
       },
     },
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6499,6 +6499,17 @@
         "sass-loader": "^7.0.1"
       }
     },
+    "gatsby-plugin-sitemap": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-sitemap/-/gatsby-plugin-sitemap-2.1.0.tgz",
+      "integrity": "sha512-9YJUx2UyeYKC8GcLZ4ZsnPAmXi6I9dxu0UDDi85HydTWhV5yC+wgbhNGZH+KlzSTlFGfyAV25cSOyoEO8dXjWg==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "minimatch": "^3.0.4",
+        "pify": "^3.0.0",
+        "sitemap": "^1.12.0"
+      }
+    },
     "gatsby-react-router-scroll": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/gatsby-react-router-scroll/-/gatsby-react-router-scroll-2.0.7.tgz",
@@ -12321,6 +12332,15 @@
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.0.tgz",
       "integrity": "sha512-N+z4pHB4AmUv0SjveWRd6q1Nj5w62m5jodv+GD8lvmbY/83T/rpbJGZOnK5T149OldDj4Db07BSv9xY4K6NTPQ=="
     },
+    "sitemap": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-1.13.0.tgz",
+      "integrity": "sha1-Vpy+IYAgKSamKiZs094Jyc60P4M=",
+      "requires": {
+        "underscore": "^1.7.0",
+        "url-join": "^1.1.0"
+      }
+    },
     "slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
@@ -13452,6 +13472,11 @@
       "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
       "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo="
     },
+    "underscore": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
+    },
     "underscore.string": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.5.tgz",
@@ -13798,6 +13823,11 @@
           "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
         }
       }
+    },
+    "url-join": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-1.1.0.tgz",
+      "integrity": "sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg="
     },
     "url-loader": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "gatsby-plugin-manifest": "2.1.1",
     "gatsby-plugin-react-helmet": "3.0.12",
     "gatsby-plugin-sass": "2.0.11",
+    "gatsby-plugin-sitemap": "2.1.0",
     "gatsby-source-filesystem": "2.0.33",
     "gatsby-transformer-remark": "2.3.12",
     "node-sass": "4.12.0",


### PR DESCRIPTION
# Description
Adds the gatsby-plugin-sitemap plugin to generate a sitemap during
the build process.

The plugin has been configured so that:
- A sitemap index will be used if the sitemap gets too big
  (more than 5000 urls).
- Ignores the 404 page (default configuration)

# Changes
- Added the sitemap plugin
- Added a constant `SITE_URL` to gatsby-config to avoid repetition of the site's url in the config