### PR TITLE
Refactor StaticQuery components to use gatsby's useStaticQuery hook

### DIFF
--- a/src/components/InterestList.jsx
+++ b/src/components/InterestList.jsx
@@ -1,61 +1,28 @@
 import React from 'react';
-import { StaticQuery, graphql } from 'gatsby';
+import useInterests from '../hooks/useInterests';
 
 /**
  * Display all interest posts in list ordered alphabetically
  */
 function InterestList() {
-  return (
-    <StaticQuery
-      query={graphql`
-        query InterestsQuery {
-          allMarkdownRemark (
-            filter: {
-              frontmatter: {
-                category: { eq: "interests" }
-              }
-            }
-            sort: {
-              fields: frontmatter___order
-              order: ASC
-            }
-          ) {
-            edges {
-              node {
-                frontmatter {
-                  title
-                }
-                id
-                html
-              }
-            }
-          }
-        }
-      `}
-      render={({ allMarkdownRemark }) => {
-        const interestItems = allMarkdownRemark.edges.map((edge) => {
-          const { id, html } = edge.node;
-          const { title } = edge.node.frontmatter;
+  const interestItems = useInterests().map((interest) => {
+    const { id, title, html } = interest;
+    return (
+      <li className="grid__item card" key={id}>
+        <div className="card__header">
+          <div className="card__title">{title}</div>
+        </div>
+        {/*
+          The html inserted here is trusted as it is static content added by gatsby during
+          build time.
+        */}
+        {/* eslint-disable-next-line react/no-danger */}
+        <div className="markdown" dangerouslySetInnerHTML={{ __html: html }} />
+      </li>
+    );
+  });
 
-          return (
-            <li className="grid__item card" key={id}>
-              <div className="card__header">
-                <div className="card__title">{title}</div>
-              </div>
-              {/*
-                The html inserted here is trusted as it is static content added by gatsby during
-                build time.
-              */}
-              {/* eslint-disable-next-line react/no-danger */}
-              <div className="markdown" dangerouslySetInnerHTML={{ __html: html }} />
-            </li>
-          );
-        });
-
-        return <ul className="grid">{interestItems}</ul>;
-      }}
-    />
-  );
+  return <ul className="grid">{interestItems}</ul>;
 }
 
 export default InterestList;

--- a/src/components/OccupationHistory.jsx
+++ b/src/components/OccupationHistory.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { StaticQuery, graphql } from 'gatsby';
+import useOccupations from '../hooks/useOccupations';
 
 const propTypes = {
   /* The category used to filter all occupations */
@@ -27,71 +27,33 @@ function OccupationHistory({ category }) {
     return `${organisation}, ${dates}`;
   }
 
-  return (
-    <StaticQuery
-      query={graphql`
-        query EmploymentHistoryQuery {
-          allMarkdownRemark (
-            filter: {
-              frontmatter: {
-                category: { in: ["jobs", "education"] }
-              }
-            }
-            sort: {
-              fields: [frontmatter___endYear]
-              order: DESC
-            }
-          ) {
-            edges {
-              node {
-                frontmatter {
-                  title
-                  category
-                  organisation
-                  startYear
-                  endYear
-                }
-                id
-                html
-              }
-            }
-          }
-        }
-      `}
-      render={(({ allMarkdownRemark }) => {
-        const items = allMarkdownRemark.edges.filter((edge) => {
-          // Filter all occupations by category.
-          const { frontmatter } = edge.node;
-          return frontmatter.category === category;
-        }).map((edge) => {
-          const { id, html } = edge.node;
-          const {
-            title,
-            organisation,
-            startYear,
-            endYear,
-          } = edge.node.frontmatter;
+  const occupations = useOccupations().filter(occupation => occupation.category === category);
+  const occupationNodes = occupations.map((occupation) => {
+    const { id, html } = occupation;
+    const {
+      title,
+      organisation,
+      startYear,
+      endYear,
+    } = occupation;
 
-          return (
-            <section key={id} className="card history-item">
-              <div className="card__header">
-                <h3 className="card__title">{title}</h3>
-                <div className="card__subtitle">{getSubtitle(organisation, startYear, endYear)}</div>
-              </div>
-              {/*
-                  The html inserted here is trusted as it is static content added by gatsby during
-                  build time.
-                */}
-              {/* eslint-disable-next-line react/no-danger */}
-              <div className="markdown" dangerouslySetInnerHTML={{ __html: html }} />
-            </section>
-          );
-        });
+    return (
+      <section key={id} className="card history-item">
+        <div className="card__header">
+          <h3 className="card__title">{title}</h3>
+          <div className="card__subtitle">{getSubtitle(organisation, startYear, endYear)}</div>
+        </div>
+        {/*
+            The html inserted here is trusted as it is static content added by gatsby during
+            build time.
+          */}
+        {/* eslint-disable-next-line react/no-danger */}
+        <div className="markdown" dangerouslySetInnerHTML={{ __html: html }} />
+      </section>
+    );
+  });
 
-        return items;
-      })}
-    />
-  );
+  return occupationNodes;
 }
 
 OccupationHistory.propTypes = propTypes;

--- a/src/components/PageMetadata.jsx
+++ b/src/components/PageMetadata.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Helmet from 'react-helmet';
-import { StaticQuery, graphql } from 'gatsby';
+import useSiteMetadata from '../hooks/usePageMetadata';
 
 const propTypes = {
   title: PropTypes.string,
@@ -13,62 +13,45 @@ const defaultProps = {
   description: '',
 };
 
-class PageMetadata extends React.Component {
-  /**
-   * Generates the full title for the given page. This is expected to be composed of the page's
-   * title and site's title.
-   * @param {string} title The page's title
-   * @param {string} siteTitle The site's title.
-   * @returns {string} The full title for this page.
-   */
-  static getPageTitle(title, siteTitle) {
-    let pageTitle = siteTitle;
+/**
+ * Generates the full title for the given page. This is expected to be composed of the page's
+ * title and site's title.
+ * @param {string} title The page's title
+ * @param {string} siteTitle The site's title.
+ * @returns {string} The full title for this page.
+ */
+function getPageTitle(title, siteTitle) {
+  let pageTitle = siteTitle;
 
-    if (title) {
-      pageTitle = `${title} | ${siteTitle}`;
-    }
-
-    return pageTitle;
+  if (title) {
+    pageTitle = `${title} | ${siteTitle}`;
   }
 
-  /**
-   * Limit the given description to a maxiumum length of 155, which is seo friendly.
-   * @param {string} description The description
-   * @returns {string} The seo friendly description.
-   */
-  static getSeoDescription(description = '') {
-    return `${description}`.substring(0, 155);
-  }
+  return pageTitle;
+}
 
-  render() {
-    const {
-      title,
-      description,
-    } = this.props;
+/**
+ * Limit the given description to a maxiumum length of 155, which is seo friendly.
+ * @param {string} description The description
+ * @returns {string} The seo friendly description.
+ */
+function getSeoDescription(description = '') {
+  return `${description}`.substring(0, 155);
+}
 
-    return (
-      <StaticQuery
-        query={graphql`
-          query PageMetadataQuery {
-            site {
-              siteMetadata {
-                title
-              }
-            }
-          }
-        `}
-        render={data => (
-          <Helmet>
-            <title>{PageMetadata.getPageTitle(title, data.site.siteMetadata.title)}</title>
-            <meta name="description" content={PageMetadata.getSeoDescription(description)} />
-          </Helmet>
-        )}
-      />
-    );
-  }
+function PageMetadata({ title, description }) {
+  const siteMetadata = useSiteMetadata();
+  return (
+    <Helmet>
+      <title>{PageMetadata.getPageTitle(title, siteMetadata.title)}</title>
+      <meta name="description" content={PageMetadata.getSeoDescription(description)} />
+    </Helmet>
+  );
 }
 
 PageMetadata.propTypes = propTypes;
 PageMetadata.defaultProps = defaultProps;
+PageMetadata.getPageTitle = getPageTitle;
+PageMetadata.getSeoDescription = getSeoDescription;
 
 export default PageMetadata;

--- a/src/components/SkillList.jsx
+++ b/src/components/SkillList.jsx
@@ -1,60 +1,28 @@
 import React from 'react';
-import { StaticQuery, graphql } from 'gatsby';
+import useSkills from '../hooks/useSkills';
 
 /**
  * Display all posts in the skills category in a grid where each skill has a title and a
  * description.
  */
 function SkillList() {
-  return (
-    <StaticQuery
-      query={graphql`
-        query SkillsQuery {
-          allMarkdownRemark (
-            filter: {
-              frontmatter: {
-                category: { eq: "skills" }
-              }
-            }
-            sort: {
-              fields: frontmatter___order
-              order: ASC
-            }
-          ) {
-            edges {
-              node {
-                frontmatter {
-                  title
-                }
-                id
-                html
-              }
-            }
-          }
-        }
-      `}
-      render={({ allMarkdownRemark }) => {
-        const skillItems = allMarkdownRemark.edges.map((edge) => {
-          const { id, html } = edge.node;
-          const { title } = edge.node.frontmatter;
+  const skillItems = useSkills().map((skillItem) => {
+    const { id, title, html } = skillItem;
 
-          return (
-            <li key={id} className="grid__item card card--primary">
-              <span className="card__title">{title}</span>
-              {/*
-                The html inserted here is trusted as it is static content added by gatsby during
-                build time.
-              */}
-              {/* eslint-disable-next-line react/no-danger */}
-              <div className="markdown" dangerouslySetInnerHTML={{ __html: html }} />
-            </li>
-          );
-        });
+    return (
+      <li key={id} className="grid__item card card--primary">
+        <span className="card__title">{title}</span>
+        {/*
+          The html inserted here is trusted as it is static content added by gatsby during
+          build time.
+        */}
+        {/* eslint-disable-next-line react/no-danger */}
+        <div className="markdown" dangerouslySetInnerHTML={{ __html: html }} />
+      </li>
+    );
+  });
 
-        return <ul className="grid">{skillItems}</ul>;
-      }}
-    />
-  );
+  return <ul className="grid">{skillItems}</ul>;
 }
 
 export default SkillList;

--- a/src/hooks/useInterests.js
+++ b/src/hooks/useInterests.js
@@ -1,0 +1,43 @@
+import { graphql, useStaticQuery } from 'gatsby';
+
+/**
+ * Get all posts in the 'interests' category.
+ */
+export default function useInterests() {
+  const { allMarkdownRemark } = useStaticQuery(
+    graphql`
+      query InterestsQuery {
+        allMarkdownRemark (
+          filter: {
+            frontmatter: {
+              category: { eq: "interests" }
+            }
+          }
+          sort: {
+            fields: frontmatter___order
+            order: ASC
+          }
+        ) {
+          edges {
+            node {
+              frontmatter {
+                title
+              }
+              id
+              html
+            }
+          }
+        }
+      }
+    `,
+  );
+
+  return allMarkdownRemark.map((edge) => {
+    const { html, id } = edge.node;
+    return {
+      ...edge.node.frontmatter,
+      html,
+      id,
+    };
+  });
+}

--- a/src/hooks/useInterests.js
+++ b/src/hooks/useInterests.js
@@ -32,7 +32,7 @@ export default function useInterests() {
     `,
   );
 
-  return allMarkdownRemark.map((edge) => {
+  return allMarkdownRemark.edges.map((edge) => {
     const { html, id } = edge.node;
     return {
       ...edge.node.frontmatter,

--- a/src/hooks/useOccupations.js
+++ b/src/hooks/useOccupations.js
@@ -1,0 +1,48 @@
+import { graphql, useStaticQuery } from 'gatsby';
+
+/**
+ * Get all posts in the occupations category.
+ */
+export default function useOccupations() {
+  const { allMarkdownRemark } = useStaticQuery(
+    graphql`
+      query EmploymentHistoryQuery {
+        allMarkdownRemark (
+          filter: {
+            frontmatter: {
+              category: { in: ["jobs", "education"] }
+            }
+          }
+          sort: {
+            fields: [frontmatter___endYear]
+            order: DESC
+          }
+        ) {
+          edges {
+            node {
+              frontmatter {
+                title
+                category
+                organisation
+                startYear
+                endYear
+              }
+              id
+              html
+            }
+          }
+        }
+      }
+    `,
+  );
+
+  return allMarkdownRemark.edges.map((edge) => {
+    const { html, id } = edge.node;
+
+    return {
+      ...edge.node.frontmatter,
+      id,
+      html,
+    };
+  });
+}

--- a/src/hooks/usePageMetadata.js
+++ b/src/hooks/usePageMetadata.js
@@ -1,0 +1,17 @@
+import { graphql, useStaticQuery } from 'gatsby';
+
+export default function useSiteMetadata() {
+  const { site } = useStaticQuery(
+    graphql`
+      query PageMetadataQuery {
+        site {
+          siteMetadata {
+            title
+          }
+        }
+      }
+    `,
+  );
+
+  return site.siteMetadata;
+}

--- a/src/hooks/useSkills.js
+++ b/src/hooks/useSkills.js
@@ -1,0 +1,45 @@
+import { graphql, useStaticQuery } from 'gatsby';
+
+/**
+ * Get all posts in the skills category.
+ */
+export default function useSkills() {
+  const { allMarkdownRemark } = useStaticQuery(
+    graphql`
+      query SkillsQuery {
+        allMarkdownRemark (
+          filter: {
+            frontmatter: {
+              category: { eq: "skills" }
+            }
+          }
+          sort: {
+            fields: frontmatter___order
+            order: ASC
+          }
+        ) {
+          edges {
+            node {
+              frontmatter {
+                title
+              }
+              id
+              html
+            }
+          }
+        }
+      }
+    `,
+  );
+
+  return allMarkdownRemark.edges.map((edge) => {
+    const { html, id } = edge.node;
+    const { title } = edge.node.frontmatter;
+
+    return {
+      html,
+      id,
+      title,
+    };
+  });
+}


### PR DESCRIPTION
# Description
Improve seperation of concerns and reduce coupling by moving GraphQL queries built into components such as SkillList, InterestList, OccupationHistory and PageMetadata into a file separated from their corresponding component.
# Changes
- Added a `./src/hooks` folder to contain the GraphQL queries.
- InterestList: removed StaticQuery context and use the `./src/hooks/useInterests` hook
  - moved the GraphQL query into `useInterests` hook instead.
- OccupationHistory: 
  - moved the GraphQL query into `.src/hooks/useOccupations`
  - removed StaticQuery context and use the `useOccupations` hook instead.
- PageMetadata: 
  - moved the GraphQL query into `./src/hooks/usePageMetadata`
  - refactor the PageMetadata class component into a functional component as react hooks cannot be used in class components.
  - remove StaticQuery context and use the `usePageMetadata` hook instead.
- SkillList: 
  - moved the GraphQL query into `./src/hooks/useSkills`
  - removed StaticQuery context and use the `useSkills` hook instead.