### PR TITLE
Implement new page header change

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -1,5 +1,10 @@
 import React from 'react';
-import { FaGithub } from 'react-icons/fa';
+import {
+  FaComments,
+  FaGithub,
+  FaGraduationCap,
+  FaLaptopCode,
+} from 'react-icons/fa';
 import Layout from '../components/Layout';
 import PageMetadata from '../components/PageMetadata';
 import SkillList from '../components/SkillList';
@@ -16,22 +21,34 @@ export default () => (
       <div className="hero">
         <div className="hero__content">
           <h1 className="hero__title">Christopher Wheatley</h1>
-          <p className="hero__lead">
-            Software Developer with a degree in computer science and 4 years commercial experience
-            using web technologies. Conscientious, committed and friendly.
-          </p>
-          <div className="hero__actions">
-            <ProtectedEmailLink base64Email="Y2hyaXNAY2hyaXN0b3BoZXJ3aGVhdGxleS51aw==" />
-            <a
-              className="button button--transparent-light"
-              href="https://github.com/chriswheatley"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <FaGithub className="button__icon" />
-              View Projects
-            </a>
-          </div>
+        </div>
+        <div className="hero__content">
+          <ul className="hero__list">
+            <li className="hero__list-item">
+              <FaLaptopCode className="hero__list-icon" />
+              <span>Software Developer with over 4 years commercial experience.</span>
+            </li>
+            <li className="hero__list-item">
+              <FaGraduationCap className="hero__list-icon" />
+              <span>Computer Science degree.</span>
+            </li>
+            <li className="hero__list-item">
+              <FaComments className="hero__list-icon" />
+              <span>Conscientious, comitted and friendly.</span>
+            </li>
+          </ul>
+        </div>
+        <div className="hero__content">
+          <ProtectedEmailLink className="hero--btn-radius" base64Email="Y2hyaXNAY2hyaXN0b3BoZXJ3aGVhdGxleS51aw==" />
+          <a
+            className="button button--transparent-light hero--btn-radius"
+            href="https://github.com/chriswheatley"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <FaGithub className="button__icon" />
+            View Projects
+          </a>
         </div>
       </div>
       <section className="panel">

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -13,12 +13,14 @@ export default () => (
       description="Find out about Christopher Wheatley's skills, experience and qualifications in software development."
     />
     <article>
-      <div className="panel panel--pageHeader">
-        <h1 className="panel__header">Christopher Wheatley</h1>
-        <div className="panel__body">
-          Software Developer with a degree in computer science and 4 years commercial experience
-          using web technologies. Conscientious, committed and friendly.
-          <div className="panel__actions">
+      <div className="hero">
+        <div className="hero__content">
+          <h1 className="hero__title">Christopher Wheatley</h1>
+          <p className="hero__lead">
+            Software Developer with a degree in computer science and 4 years commercial experience
+            using web technologies. Conscientious, committed and friendly.
+          </p>
+          <div className="hero__actions">
             <ProtectedEmailLink base64Email="Y2hyaXNAY2hyaXN0b3BoZXJ3aGVhdGxleS51aw==" />
             <a
               className="button button--transparent-light"

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -4,6 +4,7 @@ import {
   FaGithub,
   FaGraduationCap,
   FaLaptopCode,
+  FaMapMarkerAlt,
 } from 'react-icons/fa';
 import Layout from '../components/Layout';
 import PageMetadata from '../components/PageMetadata';
@@ -21,6 +22,10 @@ export default () => (
       <div className="hero">
         <div className="hero__content">
           <h1 className="hero__title">Christopher Wheatley</h1>
+          <div className="hero__list-item">
+            <FaMapMarkerAlt className="hero__list-icon" />
+            <span>United Kingdom</span>
+          </div>
         </div>
         <div className="hero__content">
           <ul className="hero__list">

--- a/src/styles/hero.scss
+++ b/src/styles/hero.scss
@@ -19,16 +19,20 @@ $skew-origin: bottom left;
   &__content {
     width: 100%;
     max-width: 105rem;
-    margin: 0 auto;
-    padding: 4rem 0;
+    margin: 1rem auto;
 
     //Correct for the skew in the parent element.
     transform: skewY($skew * -1);
     transform-origin: $skew-origin;
+
+    font-size: 1.8rem;
+    @media (min-width: 768px) {
+      font-size: 1.9rem;
+    }
   }
 
   &__title {
-    margin: 0 0 1rem 0;
+    margin: 0;
 
     font-size: 4.5rem;
     @media (min-width: 768px) {
@@ -36,17 +40,27 @@ $skew-origin: bottom left;
     }
   }
 
-  &__lead {
+  &__list {
     max-width: 70rem;
     margin: 1rem 0;
+    padding: 0;
 
-    font-size: 1.8rem;
-    @media (min-width: 768px) {
-      font-size: 2.2rem;
+    list-style: none;
+
+    &-item {
+      display: flex;
+      align-items: flex-start;
+      flex-direction: row;
+
+      margin: .25rem 0;
     }
-  }
 
-  &__actions {
-    margin-top: 5rem;
+    &-icon {
+      flex-shrink: 0;
+
+      width: 1.5em;
+      height: 1.5em;
+      margin-right: 2rem;
+    }
   }
 }

--- a/src/styles/hero.scss
+++ b/src/styles/hero.scss
@@ -5,11 +5,12 @@ $skew-origin: bottom left;
   display: flex;
   flex-direction: column;
   justify-content: center;
+
   min-height: 50vh;
+  padding: 0 1rem;
 
   background-color: $primary-500;
   color: white;
-
   //MS Edge: Use skew instead of clip-path polygon() due to browser compatibility.
   transform: skewY($skew);
   transform-origin: $skew-origin;
@@ -19,7 +20,7 @@ $skew-origin: bottom left;
     width: 100%;
     max-width: 105rem;
     margin: 0 auto;
-    padding: 4rem 1rem;
+    padding: 4rem 0;
 
     //Correct for the skew in the parent element.
     transform: skewY($skew * -1);

--- a/src/styles/hero.scss
+++ b/src/styles/hero.scss
@@ -6,8 +6,7 @@ $skew-origin: bottom left;
   flex-direction: column;
   justify-content: center;
 
-  min-height: 50vh;
-  padding: 0 1rem;
+  padding: 6vh 1rem;
 
   background-color: $primary-500;
   color: white;

--- a/src/styles/hero.scss
+++ b/src/styles/hero.scss
@@ -26,9 +26,6 @@ $skew-origin: bottom left;
     transform-origin: $skew-origin;
 
     font-size: 1.8rem;
-    @media (min-width: 768px) {
-      font-size: 1.9rem;
-    }
   }
 
   &__title {

--- a/src/styles/hero.scss
+++ b/src/styles/hero.scss
@@ -1,0 +1,51 @@
+$skew: -2deg;
+$skew-origin: bottom left;
+
+.hero {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  min-height: 50vh;
+
+  background-color: $primary-500;
+  color: white;
+
+  //MS Edge: Use skew instead of clip-path polygon() due to browser compatibility.
+  transform: skewY($skew);
+  transform-origin: $skew-origin;
+
+
+  &__content {
+    width: 100%;
+    max-width: 105rem;
+    margin: 0 auto;
+    padding: 4rem 1rem;
+
+    //Correct for the skew in the parent element.
+    transform: skewY($skew * -1);
+    transform-origin: $skew-origin;
+  }
+
+  &__title {
+    margin: 0 0 1rem 0;
+
+    font-size: 4.5rem;
+    @media (min-width: 768px) {
+      font-size: 5.5rem;
+    }
+  }
+
+  &__lead {
+    max-width: 70rem;
+    margin: 1rem 0;
+
+    font-size: 1.8rem;
+    @media (min-width: 768px) {
+      font-size: 2.2rem;
+    }
+  }
+
+  &__actions {
+    margin-top: 5rem;
+  }
+}

--- a/src/styles/hero.scss
+++ b/src/styles/hero.scss
@@ -24,7 +24,7 @@ $skew-origin: bottom left;
     transform: skewY($skew * -1);
     transform-origin: $skew-origin;
 
-    font-size: 1.8rem;
+    font-size: 1.7rem;
   }
 
   &__title {

--- a/src/styles/hero.scss
+++ b/src/styles/hero.scss
@@ -39,7 +39,7 @@ $skew-origin: bottom left;
 
   &__list {
     max-width: 70rem;
-    margin: 1rem 0;
+    margin: 0;
     padding: 0;
 
     list-style: none;

--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -3,6 +3,7 @@
 @import './colour';
 @import './footer';
 @import './header';
+@import './hero.scss';
 @import './history';
 @import './markdown';
 @import './panel';


### PR DESCRIPTION
# Description

This implements a new `hero` block / component which replaces the existing `.panel .panel--pageHeader` design for the index page.  The new design, utilises more whitespace and is more stylistic, applying a skew to the background.  

The contents of the header (personal summary) on the index page have also been revised into a list rather than a paragraph this should make it easier for users to scan / read.

# Changes
- Implemented new page header as the reusable `hero` block / component.
- Updated page header for main page.
- Revised personal summary into a list rather than a paragraph.
