### PR TITLE
fix: remove '--fix' flag from 'npm run lint'

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "source for christopherwheatley.uk",
   "private": true,
   "scripts": {
-    "lint": "eslint --fix --ext .js --ext .jsx .",
+    "lint": "eslint --ext .js --ext .jsx .",
     "test": "echo \"Warning! No tests specified\"",
     "develop": "gatsby develop",
     "build": "gatsby build",


### PR DESCRIPTION
eslint will no longer automatically fix lint errors (e.g. missing
semicolon) when invoked from 'npm run lint'

This change is made so that 'npm run lint' behaves as the user expects,
and so that it can be used in commands where source changes
are not desired.