### PR TITLE
fix: page description to be less than 155 chars

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -15,7 +15,7 @@ import ProtectedEmailLink from '../components/ProtectedEmailLink';
 
 const pageDescription = [
   'Christopher Wheatley is a software developer in the UK with 4 years\' commercial',
-  'experience. He is a committed team worker with an eye for pixel-perect detail.',
+  'experience. He is a committed team worker with an eye for detail.',
 ].join(' ');
 
 const IndexPage = () => (


### PR DESCRIPTION
This ensures the page description is seo friendly and isn't truncated

## Changes
- Updated homepage meta description (`index.jsx`) to be less than 155 characaters